### PR TITLE
Don't overwrite CXX/AR from environment. Don't spuriously call srand(), rand() is not used in library code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CXX = g++
-AR  = ar
+CXX ?= g++
+AR  ?= ar
 RL  = ranlib
 CP  = cp -r
 

--- a/src/libtwofish.cpp
+++ b/src/libtwofish.cpp
@@ -123,8 +123,6 @@ void iv2hex( const char* p, size_t l, cipherInstance* ci )
 TwoFish::TwoFish( uint8_t* key, size_t keylen, const char* iv, size_t ivlen )
  : context( NULL )
 {
-    srand((unsigned) time(NULL));
-    
     // it must be rebuild MDS at once.
     BuildMDS();
 


### PR DESCRIPTION
Before:
```
g++ -fdebug-default-version=3 -Isrc  -std=c++11 -Os  -c src/tfish.cpp -o obj/tfish.o
g++: error: unrecognized command-line option ‘-fdebug-default-version=3’
make: *** [Makefile:79: obj/tfish.o] Error 1
```

After:
```
c++ -fdebug-default-version=3 -Isrc  -std=c++11 -Os  -c src/tfish.cpp -o obj/tfish.o
src/tfish.cpp:659:13: warning: 'register' storage class specifier is deprecated and incompatible with C++17 [-Wdeprecated-register]
  659 |             sb128(0); sb128(1); sb128(2); sb128(3);
      |             ^
```